### PR TITLE
Add Highlight Slash Commands 

### DIFF
--- a/src/Mewdeko/Common/Autocompleters/HighlightAutocompleter.cs
+++ b/src/Mewdeko/Common/Autocompleters/HighlightAutocompleter.cs
@@ -1,0 +1,28 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using Mewdeko.Database;
+using Mewdeko.Modules.Highlights;
+using Mewdeko.Modules.Highlights.Services;
+
+namespace Mewdeko.Common.Autocompleters;
+
+public class HighlightAutocompleter : AutocompleteHandler
+{
+    public DiscordSocketClient Client { get; set; }
+    public IDataCache Cache { get; set; }
+    public DbService DB { get; set; }
+
+    public override Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction interaction, IParameterInfo parameter, IServiceProvider services)
+    {
+        var content = (string)interaction.Data.Current.Value;
+        var highlightsService = new HighlightsService(Client, Cache, DB);
+
+        return Task.FromResult(AutocompletionResult.FromSuccess(highlightsService.GetForGuild(context.Guild.Id)
+            .Where(x => x.UserId == context.User.Id && x.GuildId == context.Guild.Id)
+            .Select(x => x.Word = x.Word.ToLower().Replace("\n", " | "))
+            .Where(x => x.Contains(content.ToLower().Replace("\n", " | ")))
+            .Take(20)
+            .Select(x => new AutocompleteResult(x, x.Replace(" | ", "\n")))));
+    }
+}

--- a/src/Mewdeko/Modules/Highlights/Highlights.cs
+++ b/src/Mewdeko/Modules/Highlights/Highlights.cs
@@ -87,8 +87,8 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     await Task.CompletedTask;
                     var highlightsEnumerable = highlightsForUser.Skip(page * 10).Take(10);
                     return new PageBuilder().WithOkColor()
-                                     .WithTitle($"{highlightsForUser.Count()} Highlights")
-                                     .WithDescription(string.Join("\n", highlightsEnumerable.Select(x => $"{highlightsForUser.IndexOf(x)+1}. {x.Word}")));
+                        .WithTitle($"{highlightsForUser.Count()} Highlights")
+                        .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
                 }
 
                 break;
@@ -105,7 +105,7 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
 
                 if (int.TryParse(words, out var number))
                 {
-                    var todelete = highlightsForUser.ElementAt(number-1);
+                    var todelete = highlightsForUser.ElementAt(number - 1);
                     if (todelete is null)
                     {
                         await ctx.Channel.SendErrorAsync("That Highlight does not exist!");
@@ -116,9 +116,9 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     await ctx.Channel.SendConfirmAsync($"Successfully removed {Format.Code(todelete.Word)} from your highlights.");
                     return;
                 }
-                if (!highlightsForUser.Select(x => x.Word).Contains(words))
+                if (!highlightsForUser.Any(x => x.Word == words))
                 {
-                    await ctx.Channel.SendErrorAsync("This is not in your highlights!");
+                    await ctx.Channel.SendErrorAsync($"You don't have any highlights matching:\n>>> ```\n{words}\n```");
                     return;
                 }
                 await Service.RemoveHighlight(highlightsForUser.FirstOrDefault(x => x.Word == words));
@@ -150,18 +150,18 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
 
                 await _interactivity.SendPaginatorAsync(paginator, Context.Channel,
                     TimeSpan.FromMinutes(60));
-                
+
                 async Task<PageBuilder> PageFactory1(int page)
                 {
                     await Task.CompletedTask;
                     var highlightsEnumerable = matched.Skip(page * 10).Take(10).Select(x => x.Word);
                     return new PageBuilder().WithOkColor()
-                                            .WithTitle($"{matched.Count()} Highlights")
-                                            .WithDescription(string.Join("\n", highlightsEnumerable));
+                        .WithTitle($"{matched.Count()} Highlights")
+                        .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
                 }
-                
+
                 break;
-            
+
             case HighlightActions.ToggleIgnore:
                 if (string.IsNullOrWhiteSpace(words))
                     return;
@@ -173,7 +173,7 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     var reader2 = new UserTypeReader<IUser>();
                     IUser host;
                     var result1 = await reader2.ReadAsync(ctx, words, null);
-                    host = (IUser) result1.BestMatch;
+                    host = (IUser)result1.BestMatch;
                     if (host.Username is null)
                     {
                         await ctx.Channel.SendErrorAsync("That user or channel wasnt found!");
@@ -189,7 +189,7 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
 
                     return;
                 }
-                channel = (ITextChannel) result.BestMatch;
+                channel = (ITextChannel)result.BestMatch;
 
                 if (await Service.ToggleIgnoredChannel(ctx.Guild.Id, ctx.User.Id, channel.Id.ToString()))
                 {
@@ -198,7 +198,7 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                 else
                     await ctx.Channel.SendConfirmAsync($"Removed {channel.Mention} from ignored channels!");
                 break;
-            
+
             case HighlightActions.Toggle:
                 if (string.IsNullOrWhiteSpace(words))
                     return;
@@ -218,8 +218,8 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                 await Service.ToggleHighlights(ctx.Guild.Id, ctx.User.Id, enabled);
                 await ctx.Channel.SendConfirmAsync("Highlights disabled.");
                 break;
-            
+
         }
     }
-    
+
 }

--- a/src/Mewdeko/Modules/Highlights/Highlights.cs
+++ b/src/Mewdeko/Modules/Highlights/Highlights.cs
@@ -87,8 +87,8 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     await Task.CompletedTask;
                     var highlightsEnumerable = highlightsForUser.Skip(page * 10).Take(10);
                     return new PageBuilder().WithOkColor()
-                        .WithTitle($"{highlightsForUser.Count()} Highlights")
-                        .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
+                                     .WithTitle($"{highlightsForUser.Count()} Highlights")
+                                     .WithDescription(string.Join("\n", highlightsEnumerable.Select(x => $"{highlightsForUser.IndexOf(x) + 1}. {x.Word}")));
                 }
 
                 break;
@@ -116,9 +116,9 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     await ctx.Channel.SendConfirmAsync($"Successfully removed {Format.Code(todelete.Word)} from your highlights.");
                     return;
                 }
-                if (!highlightsForUser.Any(x => x.Word == words))
+                if (!highlightsForUser.Select(x => x.Word).Contains(words))
                 {
-                    await ctx.Channel.SendErrorAsync($"You don't have any highlights matching:\n>>> ```\n{words}\n```");
+                    await ctx.Channel.SendErrorAsync("This is not in your highlights!");
                     return;
                 }
                 await Service.RemoveHighlight(highlightsForUser.FirstOrDefault(x => x.Word == words));
@@ -156,8 +156,8 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                     await Task.CompletedTask;
                     var highlightsEnumerable = matched.Skip(page * 10).Take(10).Select(x => x.Word);
                     return new PageBuilder().WithOkColor()
-                        .WithTitle($"{matched.Count()} Highlights")
-                        .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
+                                            .WithTitle($"{matched.Count()} Highlights")
+                                            .WithDescription(string.Join("\n", highlightsEnumerable));
                 }
 
                 break;

--- a/src/Mewdeko/Modules/Highlights/Highlights.cs
+++ b/src/Mewdeko/Modules/Highlights/Highlights.cs
@@ -154,10 +154,10 @@ public class Highlights : MewdekoModuleBase<HighlightsService>
                 async Task<PageBuilder> PageFactory1(int page)
                 {
                     await Task.CompletedTask;
-                    var highlightsEnumerable = matched.Skip(page * 10).Take(10).Select(x => x.Word);
+                    var highlightsEnumerable = matched.Skip(page * 10).Take(10);
                     return new PageBuilder().WithOkColor()
-                                            .WithTitle($"{matched.Count()} Highlights")
-                                            .WithDescription(string.Join("\n", highlightsEnumerable));
+                                     .WithTitle($"{highlightsForUser.Count()} Highlights")
+                                     .WithDescription(string.Join("\n", highlightsEnumerable.Select(x => $"{highlightsForUser.IndexOf(x) + 1}. {x.Word}")));
                 }
 
                 break;

--- a/src/Mewdeko/Modules/Highlights/Services/HighlightsService.cs
+++ b/src/Mewdeko/Modules/Highlights/Services/HighlightsService.cs
@@ -14,7 +14,7 @@ public class HighlightsService : INService, IReadyExecutor
     private readonly DiscordSocketClient _client;
     private readonly IDataCache _cache;
     private readonly DbService _db;
-    
+
 
     public HighlightsService(DiscordSocketClient client, IDataCache cache, DbService db)
     {
@@ -24,7 +24,7 @@ public class HighlightsService : INService, IReadyExecutor
         _ = CacheToRedis();
         _client.MessageReceived += StaggerHighlights;
         _client.UserIsTyping += AddHighlightTimer;
-        
+
     }
 
     private async Task AddHighlightTimer(Cacheable<IUser, ulong> arg1, Cacheable<IMessageChannel, ulong> _)
@@ -69,7 +69,7 @@ public class HighlightsService : INService, IReadyExecutor
     {
         if (message.Channel is not ITextChannel channel)
             return true;
-        
+
         if (string.IsNullOrWhiteSpace(message.Content))
             return true;
         var usersDMd = new List<ulong>();
@@ -186,7 +186,7 @@ public class HighlightsService : INService, IReadyExecutor
                 IgnoredChannels = "0",
                 IgnoredUsers = "0"
             };
-            var toedit1 = toadd.IgnoredUsers.Split(" ").ToList(); 
+            var toedit1 = toadd.IgnoredUsers.Split(" ").ToList();
             toedit1.Add(channelId);
             toadd.IgnoredChannels = string.Join(" ", toedit1);
             uow.HighlightSettings.Add(toadd);
@@ -212,7 +212,7 @@ public class HighlightsService : INService, IReadyExecutor
         await _cache.AddHighlightSettingToCache(guildId, current);
         return ignored;
     }
-    
+
     public async Task<bool> ToggleIgnoredUser(ulong guildId, ulong userId, string userToIgnore)
     {
         bool ignored = true;
@@ -228,7 +228,7 @@ public class HighlightsService : INService, IReadyExecutor
                 IgnoredChannels = "0",
                 IgnoredUsers = "0"
             };
-            var toedit1 = toadd.IgnoredUsers.Split(" ").ToList(); 
+            var toedit1 = toadd.IgnoredUsers.Split(" ").ToList();
             toedit1.Add(userToIgnore);
             toadd.IgnoredUsers = string.Join(" ", toedit1);
             uow.HighlightSettings.Add(toadd);
@@ -254,7 +254,7 @@ public class HighlightsService : INService, IReadyExecutor
         await _cache.AddHighlightSettingToCache(guildId, current);
         return ignored;
     }
-    
+
     public async Task RemoveHighlight(Database.Models.Highlights toremove)
     {
         await using var uow = _db.GetDbContext();
@@ -269,10 +269,10 @@ public class HighlightsService : INService, IReadyExecutor
         await _cache.RemoveHighlightFromCache(toremove.GuildId, current);
     }
 
-    public List<Database.Models.Highlights> GetForGuild(ulong guildId) 
+    public List<Database.Models.Highlights> GetForGuild(ulong guildId)
         => _cache.GetHighlightsForGuild(guildId) ?? new List<Database.Models.Highlights>();
 
-    public List<HighlightSettings> GetSettingsForGuild(ulong guildId) 
+    public List<HighlightSettings> GetSettingsForGuild(ulong guildId)
         => _cache.GetHighlightSettingsForGuild(guildId) ?? new List<HighlightSettings>();
 
 

--- a/src/Mewdeko/Modules/Highlights/SlashHighlights.cs
+++ b/src/Mewdeko/Modules/Highlights/SlashHighlights.cs
@@ -1,0 +1,189 @@
+using Discord;
+using Discord.WebSocket;
+using Fergun.Interactive;
+using Fergun.Interactive.Pagination;
+using Discord.Interactions;
+using Mewdeko._Extensions;
+using Mewdeko.Common;
+using Mewdeko.Common.Autocompleters;
+using Mewdeko.Database;
+using Mewdeko.Database.Extensions;
+using Mewdeko.Modules.Highlights.Services;
+
+namespace Mewdeko.Modules.Highlights;
+
+[Group("highlights", "Set or manage highlights")]
+public class SlashHighlights : MewdekoSlashModuleBase<HighlightsService>
+{
+    private readonly InteractiveService _interactivity;
+    private readonly IServiceProvider _svcs;
+    private readonly DbService _db;
+
+    public SlashHighlights(InteractiveService interactivity, IServiceProvider svcs, DbService db)
+    {
+        _interactivity = interactivity;
+        _svcs = svcs;
+        _db = db;
+    }
+
+    [SlashCommand("add", "Add new highlights."), RequireContext(ContextType.Guild)]
+    public async Task AddHighlight([Summary("words", "Words to highlight.")] string words)
+    {
+        await using var uow = _db.GetDbContext();
+        var highlights = uow.Highlights.ForUser(ctx.Guild.Id, ctx.User.Id).ToList();
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            await ctx.Interaction.SendErrorAsync("You need to specify a phrase to highlight.");
+            return;
+        }
+
+        if (highlights.Any() && highlights.Select(x => x.Word.ToLower()).Contains(words.ToLower()))
+            await ctx.Interaction.SendErrorAsync("That's already in your highlights");
+        else
+        {
+            await Service.AddHighlight(ctx.Guild.Id, ctx.User.Id, words);
+            await ctx.Interaction.SendConfirmAsync($"Added {Format.Code(words)} to your highlights!");
+        }
+    }
+
+    [SlashCommand("list", "List your current highlights."), RequireContext(ContextType.Guild)]
+    public async Task ListHighlights()
+    {
+        await using var uow = _db.GetDbContext();
+        var highlightsForUser = uow.Highlights.ForUser(ctx.Guild.Id, ctx.User.Id).ToList();
+
+        if (!highlightsForUser.Any())
+        {
+            await ctx.Interaction.SendErrorAsync("You have no highlights set.");
+            return;
+        }
+
+        var paginator = new LazyPaginatorBuilder()
+            .AddUser(ctx.User)
+            .WithPageFactory(PageFactory)
+            .WithFooter(PaginatorFooter.PageNumber | PaginatorFooter.Users)
+            .WithMaxPageIndex(highlightsForUser.Count() / 10)
+            .WithDefaultEmotes()
+            .Build();
+
+        await _interactivity.SendPaginatorAsync(paginator, (ctx.Interaction as SocketInteraction)!,
+            TimeSpan.FromMinutes(60));
+
+        async Task<PageBuilder> PageFactory(int page)
+        {
+            await Task.CompletedTask;
+            var highlightsEnumerable = highlightsForUser.Skip(page * 10).Take(10).Select(x => x.Word);
+            return new PageBuilder().WithOkColor()
+                .WithTitle($"{highlightsForUser.Count()} Highlights")
+                .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
+
+        }
+    }
+
+    [SlashCommand("delete", "Delete a highlight."), RequireContext(ContextType.Guild)]
+    public async Task DeleteHighlight(
+        [Autocomplete(typeof(HighlightAutocompleter)), Summary("words", "The highlight to delete.")] string words)
+    {
+
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            await ctx.Interaction.SendErrorAsync("Cannot delete an empty highlight.");
+            return;
+        }
+
+        await using var uow = _db.GetDbContext();
+        var highlightsForUser = uow.Highlights.ForUser(ctx.Guild.Id, ctx.User.Id).ToList();
+
+        if (!highlightsForUser.Any())
+        {
+            await ctx.Interaction.SendErrorAsync("Cannot delete because you have no highlights set!");
+            return;
+        }
+
+        if (int.TryParse(words, out var number))
+        {
+            var todelete = highlightsForUser.ElementAt(number - 1);
+            if (todelete is null)
+            {
+                await ctx.Interaction.SendErrorAsync("That Highlight does not exist!");
+                return;
+            }
+
+            await Service.RemoveHighlight(todelete);
+            await ctx.Interaction.SendConfirmAsync($"Successfully removed {Format.Code(todelete.Word)} from your highlights.");
+            return;
+        }
+        if (!highlightsForUser.Select(x => x.Word).Contains(words))
+        {
+            await ctx.Interaction.SendErrorAsync("This is not in your highlights!");
+            return;
+        }
+        await Service.RemoveHighlight(highlightsForUser.FirstOrDefault(x => x.Word == words));
+        await ctx.Interaction.SendConfirmAsync($"Successfully removed {Format.Code(words)} from your highlights.");
+    }
+
+    [SlashCommand("match", "Find a matching highlight."), RequireContext(ContextType.Guild)]
+    public async Task MatchHighlight(
+        [Autocomplete(typeof(HighlightAutocompleter)), Summary("words", "The highlight to find.")] string words)
+    {
+        if (string.IsNullOrWhiteSpace(words))
+        {
+            await ctx.Interaction.SendErrorAsync("Cannot match an empty highlight.");
+            return;
+        }
+
+        await using var uow = _db.GetDbContext();
+        var highlightsForUser = uow.Highlights.ForUser(ctx.Guild.Id, ctx.User.Id).ToList();
+
+        var matched = highlightsForUser.Where(x => words.ToLower().Contains(x.Word.ToLower()));
+        if (!matched.Any())
+        {
+            await ctx.Channel.SendErrorAsync("No matches found.");
+            return;
+        }
+
+        var paginator = new LazyPaginatorBuilder()
+            .AddUser(ctx.User)
+            .WithPageFactory(PageFactory1)
+            .WithFooter(PaginatorFooter.PageNumber | PaginatorFooter.Users)
+            .WithMaxPageIndex(matched.Count() / 10)
+            .WithDefaultEmotes()
+            .Build();
+
+        await _interactivity.SendPaginatorAsync(paginator, Context.Channel,
+            TimeSpan.FromMinutes(60));
+
+        async Task<PageBuilder> PageFactory1(int page)
+        {
+            await Task.CompletedTask;
+            var highlightsEnumerable = matched.Skip(page * 10).Take(10).Select(x => x.Word);
+            return new PageBuilder().WithOkColor()
+                .WithTitle($"{matched.Count()} Highlights")
+                .WithDescription(string.Concat(highlightsEnumerable.Select(x => $"```\n{x}```\n")));
+        }
+    }
+
+    [SlashCommand("ignore-user", "Ignore a specified user.")]
+    public async Task Ignore(IUser user, bool? ignore = null)
+    {
+        if (await Service.ToggleIgnoredUser(ctx.Guild.Id, ctx.User.Id, user.Id.ToString()))
+        {
+            await ctx.Channel.SendConfirmAsync($"Added {user.Mention} to ignored users!");
+            return;
+        }
+        else
+            await ctx.Channel.SendConfirmAsync($"Removed {user.Mention} from ignored users!");
+    }
+
+    [SlashCommand("ignore-channel", "Ignore a specified channel.")]
+    public async Task Ignore(ITextChannel channel, bool? ignore = null)
+    {
+        if (await Service.ToggleIgnoredUser(ctx.Guild.Id, ctx.User.Id, channel.Id.ToString()))
+        {
+            await ctx.Channel.SendConfirmAsync($"Added {channel.Mention} to ignored channels!");
+            return;
+        }
+        else
+            await ctx.Channel.SendConfirmAsync($"Removed {channel.Mention} from ignored channels!");
+    }
+}


### PR DESCRIPTION
This pr adds slash commands for `.highlight`, the commands cover all functionality `.highlight` had, and includes auto completion.
![image](https://user-images.githubusercontent.com/80918250/158710839-f2325955-35f8-4537-aee1-625cba2b189d.png)
![image](https://user-images.githubusercontent.com/80918250/158710860-bf5e6389-e4fe-4a03-be1e-f3804c8aebdb.png)
