### PR TITLE
Update highlight message.

### DIFF
--- a/src/Mewdeko/Modules/Highlights/Services/HighlightsService.cs
+++ b/src/Mewdeko/Modules/Highlights/Services/HighlightsService.cs
@@ -107,11 +107,16 @@ public class HighlightsService : INService, IReadyExecutor
                 continue;
             var messages = await channel.GetMessagesAsync(message.Id, Direction.Before, 5).FlattenAsync();
             var eb = new EmbedBuilder().WithOkColor().WithTitle(i.Word.TrimTo(100)).WithDescription(string.Join("\n",
-                                           messages.OrderBy(x => x.Timestamp).Select(x => $"**[{x.Timestamp:h:mm:ss}]**: {Format.Bold(x.Author.ToString())}: {x.Content?.TrimTo(100)}")))
-                                       .WithFooter("Yes this was shamelessly copied from carl-bot.");
+                                            messages.OrderBy(x => x.Timestamp).Select(x => $"[<t:{x.Timestamp.ToUnixTimeSeconds()}:T>]({x.GetJumpLink()}): " +
+                                                $"{Format.Bold(x.Author.ToString())}: {x.Content?.TrimTo(100)} {(x.Embeds?.Count >= 1 || x.Attachments?.Count >= 1 ? "[has embed]" : "")}")))
+                                        .WithFooter("Yes this was shamelessly copied from carl-bot.");
+
+            var cb = new ComponentBuilder()
+                .WithButton("Jump to message", style: ButtonStyle.Link, emote: Emote.Parse("<:MessageLink:778925231506587668>"), url: message.GetJumpLink());
+
             await user.SendMessageAsync(
                 $"In {Format.Bold(channel.Guild.Name)} {channel.Mention} you were mentioned with highlight word {i.Word}",
-                embed: eb.Build());
+                embed: eb.Build(), components: cb.Build());
             usersDMd.Add(user.Id);
 
         }

--- a/src/Mewdeko/_Extensions/IMessageExtentions.cs
+++ b/src/Mewdeko/_Extensions/IMessageExtentions.cs
@@ -1,0 +1,9 @@
+using Discord;
+
+namespace Mewdeko._Extensions;
+
+public static class MessageExtentions
+{
+    public static string GetJumpLink(this IMessage message)
+        => $"https://discord.com/channels/{(message.Channel is ITextChannel channel ? channel.GuildId : "@me")}/{message.Channel.Id}/{message.Id}";
+}


### PR DESCRIPTION
Changes:
- Timestamps in the highlight message now match the users preferred timezone.
- Clicking the timestamp directs the user to the in-channel message
- Messages that have embeds or files attached are marked (so it's clear why they don't appear to have any content)
- Added a jump to message button so the user doesn't have to scroll.
![image](https://user-images.githubusercontent.com/80918250/159541272-f700aed0-66ec-4733-ac1a-0dd5ccb0049f.png)
